### PR TITLE
Multiple products

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,20 +7,26 @@
     <script src="javascripts/storeController.js"></script>
   </head>
   <body ng-controller="StoreController as storeCtrl">
-    <ul ng-repeat="product in storeCtrl.products">Products:
-      <li>
-        <span> {{ product.productName }} </span>
-        <span> £{{ product.price.toFixed(2) }} </span>
-        <button ng-click="storeCtrl.addToCart(product)">Add to cart</button>
-      </li>
-    </ul>
-    <ul ng-repeat="cartItem in storeCtrl.shoppingCart">Shopping cart:
-      <li>
-        <span> {{ cartItem.productName }} </span>
-        <span> £{{ cartItem.price.toFixed(2) }} </span>
-        <button ng-click="storeCtrl.remove(cartItem)">Remove from cart</button>
-      </li>
-    </ul>
-    <p>Total: {{ storeCtrl.cartTotal() }}</p>
+    <div>
+      Products:
+      <ul ng-repeat="product in storeCtrl.products">Products:
+        <li>
+          <span> {{ product.name }} </span>
+          <span> £{{ product.price.toFixed(2) }} </span>
+          <button ng-click="storeCtrl.addToCart(product)">Add to cart</button>
+        </li>
+      </ul>
+    </div>
+    <div>
+      Shopping Cart
+      <ul ng-repeat="item in storeCtrl.shoppingCart">
+        <li>
+          <span> {{ item.name }} </span>
+          <span> £{{ item.price.toFixed(2) }} </span>
+          <button ng-click="storeCtrl.remove(item)">Remove from cart</button>
+        </li>
+      </ul>
+      <p>Total: {{ storeCtrl.cartTotal() }}</p>
+    </div>
   </body>
 </html>

--- a/public/javascripts/products.js
+++ b/public/javascripts/products.js
@@ -1,6 +1,56 @@
 'use strict';
 var store = {};
-store.products = [{
-    productName: 'Almond Toe Court Shoes, Patent Black',
-    price: 99
-}];
+store.products = [
+    {
+        name: 'Almond Toe Court Shoes, Patent Black',
+        price: 99
+    },
+    {
+        name: 'Suede Shoes, Blue',
+        price: 42
+    },
+    {
+        name: 'Leather Driver Saddle Loafers, Tan',
+        price: 34
+    },
+    {
+        name: 'Flip Flops, Red',
+        price: 19
+    },
+    {
+        name: 'Flip Flops, Blue',
+        price: 19
+    },
+    {
+        name: 'Gold Button Cardigan, Black',
+        price: 167
+    },
+    {
+        name: 'Cotton Shorts, Medium Red',
+        price: 30
+    },
+    {
+        name: 'Fine Stripe Short Sleeve Shirt, Grey',
+        price: 49.99
+    },
+    {
+        name: 'Fine Stripe Short Sleeve Shirt, Green',
+        price: 39.99
+    },
+    {
+        name: 'Sharkskin Waistcoat, Charcoal',
+        price: 75
+    },
+    {
+        name: 'Lightweight Patch Pocket Blazer, Deer',
+        price: 175
+    },
+    {
+        name: 'Bird Print Dress, Black',
+        price: 270
+    },
+    {
+        name: 'Mid Twist Cut-Out Dress, Pink',
+        price: 540
+    }
+];

--- a/test/e2e/adding-product-to-cart-spec.js
+++ b/test/e2e/adding-product-to-cart-spec.js
@@ -1,8 +1,8 @@
 describe('Adding a product to the shopping cart', function () {
     var productList  = element.all(by.repeater('product in storeCtrl.products'));
-    var productName   = element(by.binding('product.productName'));
+    var productName   = element(by.binding('product.name'));
     var addProductBtn = element(by.buttonText('Add to cart'));
-    var cartItemName  = element(by.binding('cartItem.productName'));
+    var cartItemName  = element(by.binding('cartItem.name'));
     beforeEach(function () {
         browser.get('http://localhost:8080');
     });

--- a/test/spec/productsSpec.js
+++ b/test/spec/productsSpec.js
@@ -4,7 +4,7 @@ describe("Products", function () {
     });
     describe('a product', function () {
         it('should have a product name', function () {
-            expect(store.products[0].productName).toEqual('Almond Toe Court Shoes, Patent Black');            
+            expect(store.products[0].name).toEqual('Almond Toe Court Shoes, Patent Black');            
         });
         it('should have a price', function () {
             expect(store.products[0].price).toEqual(99);

--- a/test/spec/storeControllerSpec.js
+++ b/test/spec/storeControllerSpec.js
@@ -15,7 +15,7 @@ describe('StoreController', function () {
     });
     it('should allow a user to add a product to their shopping cart', function () {
         ctrl.addToCart(store.products[0])
-        expect(ctrl.shoppingCart).toEqual([{ productName: 'Almond Toe Court Shoes, Patent Black', price: 99 }]);
+        expect(ctrl.shoppingCart).toEqual([{ name: 'Almond Toe Court Shoes, Patent Black', price: 99 }]);
     });
     it('should allow a user to remove a product from their cart', function () {
         ctrl.addToCart(store.products[0]);


### PR DESCRIPTION
- adding the rest of the store products (with name and price only)
- no need to change any other implementation: the app functions with multiple products
- changed `productName` property of elements in the product list to plain old `name`
