### PR TITLE
Add 15 off voucher

### DIFF
--- a/public/javascripts/storeController.js
+++ b/public/javascripts/storeController.js
@@ -25,6 +25,8 @@ clothesStore.controller('StoreController', function () {
         }
     };
     function basketIncludes (category) {
-        return self.basket.some(elem => elem.category.indexOf(category) > -1);
+        return self.basket.some(function(elem) {
+            return elem.category.indexOf(category) > -1;
+        });
     };
 });

--- a/public/javascripts/storeController.js
+++ b/public/javascripts/storeController.js
@@ -18,8 +18,13 @@ clothesStore.controller('StoreController', function () {
             self.total -= 5;
         } else if (voucher == 'tenner' && self.total > 50) {
             self.total -= 10;
+        } else if (voucher == 'fifteen' && self.total > 75 && basketIncludes('Footwear')) {
+            self.total -= 15;
         } else {
             self.voucherError = 'invalid code';
         }
+    };
+    function basketIncludes (category) {
+        return self.basket.some(elem => elem.category.indexOf(category) > -1);
     };
 });

--- a/test/e2e/adding-product-to-cart-spec.js
+++ b/test/e2e/adding-product-to-cart-spec.js
@@ -1,16 +1,20 @@
 describe('Adding a product to the shopping cart', function () {
-    var productList  = element.all(by.repeater('product in storeCtrl.products'));
-    var productName   = element(by.binding('product.name'));
-    var addProductBtn = element(by.buttonText('Add to cart'));
+    var items  = element.all(by.repeater('product in storeCtrl.products'));
+    var courtShoesElmnts = items.filter(function (elem) {
+        return elem.getText().then(function(text) {
+            return (text.indexOf('Court Shoes') > -1);
+        });
+    });
+    var buyCourtShoesBtn = courtShoesElmnts.get(0).element(by.buttonText('Add to cart'));
     var cartItemName  = element(by.binding('item.name'));
     beforeEach(function () {
         browser.get('http://localhost:8080');
     });
     it('should display product name(s)', function () {
-        expect(productName.getText()).toEqual('Almond Toe Court Shoes, Patent Black');
+        expect(courtShoesElmnts.get(0).element(by.binding('product.name')).getText()).toEqual('Almond Toe Court Shoes, Patent Black');
     });
     it('should allow a user to add a product to their cart', function () {
-        addProductBtn.click();
+        buyCourtShoesBtn.click();
 
         expect(cartItemName.getText()).toEqual('Almond Toe Court Shoes, Patent Black');
     });

--- a/test/e2e/applying-a-voucher-spec.js
+++ b/test/e2e/applying-a-voucher-spec.js
@@ -9,6 +9,12 @@ describe('Applying a voucher', function () {
         });
     });
     var buyBlueFlipflopsBtn = blueFlipflopsElmnts.get(0).element(by.buttonText('Add to cart'));
+    var courtShoesElmnts = items.filter(function (elem) {
+        return elem.getText().then(function(text) {
+            return (text.indexOf('Court Shoes') > -1);
+        });
+    });
+    var buyCourtShoesBtn = courtShoesElmnts.get(0).element(by.buttonText('Add to cart'));
     beforeEach(function () {
         browser.get('http://localhost:8080');
     });
@@ -37,5 +43,11 @@ describe('Applying a voucher', function () {
         discountCodeField.sendKeys(protractor.Key.ENTER);
         expect(totalPriceEl.getText()).toEqual('Total: £19.00');
         expect(discountErrorEl.getText()).toEqual('invalid code');
+    });
+    it('should apply \'fifteen\' voucher if valid', function () {
+        buyCourtShoesBtn.click();
+        discountCodeField.sendKeys('fifteen');
+        discountCodeField.sendKeys(protractor.Key.ENTER);
+        expect(totalPriceEl.getText()).toEqual('Total: £84.00');
     });
 });

--- a/test/e2e/removing-items-from-cart-spec.js
+++ b/test/e2e/removing-items-from-cart-spec.js
@@ -1,11 +1,16 @@
 describe('Removing items from shopping cart', function () {
-    var cart = element.all(by.repeater('cartItem in storeCtrl.basket'));
+    var cart       = element.all(by.repeater('item in storeCtrl.basket'));
+    var products   = element.all(by.repeater('product in storeCtrl.products'))
+    var addBtn     = products.get(0).element(by.buttonText('Add to cart'));
+    var removeBtn  = cart.get(0).element(by.buttonText('Remove from cart'));
+
     beforeEach(function () {
         browser.get('http://localhost:8080');
     });
+
     it('should allow a user to remove an item', function () {
-        element(by.buttonText('Add to cart')).click();
-        element(by.buttonText('Remove from cart')).click();
+        addBtn.click();
+        removeBtn.click();
         expect(cart.count()).toEqual(0);
     });
 });

--- a/test/e2e/viewing-total-price-spec.js
+++ b/test/e2e/viewing-total-price-spec.js
@@ -1,6 +1,12 @@
 describe('Viewing an order\'s total price', function () {
-    var storeEl = element(by.repeater('product in storeCtrl.products'));
-    var storePriceTagEl = storeEl.element(by.binding('product.price'));
+    var products = element.all(by.repeater('product in storeCtrl.products'));
+    var storePriceTagEl = products.get(0).element(by.binding('product.price'));
+    var courtShoesElmnts = products.filter(function(element) {
+        return element.getText().then(function(text) {
+            return (text.indexOf('Court Shoes') > -1);
+        });
+    });
+    var courtShoesPrice = courtShoesElmnts.get(0).element(by.binding('product.price'));
     var cartEl = element(by.repeater('item in storeCtrl.basket'));
     var cartPriceTagEl = cartEl.element(by.binding('item.price'));
     var addItemBtn = element(by.buttonText('Add to cart'));
@@ -11,7 +17,7 @@ describe('Viewing an order\'s total price', function () {
     });
 
     it('should have a price per item in the store section', function () {
-        expect(storePriceTagEl.getText()).toEqual('£99.00');
+        expect(courtShoesPrice.getText()).toEqual('£99.00');
     });
     it('should show item prices in the cart', function () {
         element(by.buttonText('Add to cart')).click();


### PR DESCRIPTION
- user can get £15 off their order when they spend over £75 and buy some footwear
- annoying to have to replace arrow functions in StoreController's `basketIncludes` (seemingly unsupported in the browser running local Karma tests, but will get to the bottom of that.
- bug in the vouchers: can duplicate vouchers under certain circumstances
- might it be possible to avoid if / else if / else if... when applying vouchers?
